### PR TITLE
Make the disclaimer more official

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Disclaimer
 
-Disclaimer regarding the Devon Austin Wood-Thomas Github Organization:
+Disclaimer regarding the Devon Austin Wood-Thomas GitHub Organisation:
 
 ## Liability
 
-The Devon Austin Wood-Thomas Github Organization, which may in the future be referred to as "DAWT", is in no way affiliated with the individual(s) who may identify themselves with the same name. Aforementioned individuals of the same name do not have relation to, nor complete nor partial ownership of this organization without express written consent from all of the official administrators of DAWT. Neither DAWT nor any of its members may be held liable for any of the actions taken by individuals who identify themselves by the same name. Members of the DAWT Organization may not be held responsible for any publicity, either positive or negative, received by individuals of the same name without express written consent from the member in question.
+The Devon Austin Wood-Thomas GitHub Organisation ("DAWT") is in no way affiliated, authorised, maintained, sponsored or endorsed by individual(s) who may identify themselves with the same or similar name. Aforementioned individuals of the same name do not have any relation to nor have neither partial nor complete ownership of this organisation without express written consent from all the official administrators of DAWT. Neither DAWT nor any of its members may be held liable for improper use of materials created or published under DAWT including the misuse by indiviuals who bear the same or similar name to the organisation discussed herein. Members of DAWT may not be held responsible for any publicity (positive, negative or otherwise) received by individuals for reasons including but not limited to having the same or similar name without express written consent from the member(s) in question.
 
 ## Ownership
 
-The work produced and developed by DAWT, including, but not limited to: code, text, artwork (digital and hand-made), and jokes, belong to DAWT, and individuals bearing the same name have no claim on the property, and attempts to claim the work as one's own due to similarities in the nomenclature of the group and an individual may be promptly shut down with a citation to this sentence. DAWT does not acknowledge nor recognize any similarities in art produced to individuals who may have similar names to the organization. DAWT may claim full credit, if the organization chooses to do so, for monetary donations to any organization made by individuals bearing the same name.
+The work produced, developed or published by DAWT, including but not limited to code, text, artwork (digital and hand-made) and jokes, belong to DAWT, and thereby any individuals bearing the same name have no claim to such property. Attempts to claim such work as one's own due to similarities in the nomenclature of the group and an individual may be promptly discarded with a citation to this such disclaimer. DAWT does not acknowledge nor recognise any similarities in art produced to individuals who may have similar names to the organisation. DAWT may claim full credit, if the organisation chooses to do so, for donations (monetary or otherwise) to any organisation made by individuals bearing the same name ("Devon Austin Wood-Thomas").
 
 ## Penalties
 
-Failure to acknowledge the terms outlined in this disclaimer by individuals who identify themselves with a similar name to DAWT may result in forfeiture of food or other items of value.
+Failure to acknowledge the terms as outlined herein by individuals who identify themselves with the same or similar name to DAWT may result in forfeiture of items of value including but not limited to food and money.


### PR DESCRIPTION
Use correct U.S. court syntax for names

Drop the Oxford Comma

Use British English spellings

Correct capitalization errors